### PR TITLE
Update World.java: FlushActorRemoveQueue() now removes actors only once

### DIFF
--- a/src/Green/World.java
+++ b/src/Green/World.java
@@ -709,6 +709,7 @@ public abstract class World
 			_actors.remove(actor);
 			actor.removedFromWorld(this);
 		}
+		_actorRemoveQueue.clear();//clear the queue after removing the actors
 	}
 	
 	//Base Methods


### PR DESCRIPTION
clears the queue after removing the actors. (otherwise, the actor will not be deleted by the garbage collector and the removedFromWorld() method will be called once per frame)